### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/src/ardrone_sumo/CMakeLists.txt
+++ b/src/ardrone_sumo/CMakeLists.txt
@@ -20,11 +20,11 @@ find_package(cv_bridge REQUIRED)
 
 add_executable(jumping_sumo src/jumping_sumo.cpp)
 target_link_libraries(jumping_sumo PUBLIC
-  rclcpp
-  sensor_msgs
-  ardrone_sdk
-  OpenCV
-  cv_bridge
+  ${sensor_msgs_TARGETS}
+  ardrone_sdk::ardrone_sdk
+  cv_bridge::cv_bridge
+  rclcpp::rclcpp
+  sensor_msgs::sensor_msgs_library
 )
 
 install(TARGETS

--- a/src/ardrone_sumo/CMakeLists.txt
+++ b/src/ardrone_sumo/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(OpenCV REQUIRED)
 find_package(cv_bridge REQUIRED)
 
 add_executable(jumping_sumo src/jumping_sumo.cpp)
-ament_target_dependencies(jumping_sumo 
+target_link_libraries(jumping_sumo PUBLIC
   rclcpp
   sensor_msgs
   ardrone_sdk


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
